### PR TITLE
Use better mask for read_id and write_id. Stop using filters when wai…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [ongoing] - 2024-04-26
+### Changed
+- Use notifier from can library to allow sharing the bus with other bus users, #7
+
+### Fixed
+- Fix communication when bus is set before starting , #5
+
+
 ## [0.1.2] - 2024-04-15
 ### Changed
 - Move CanMessage/CanSignal inherited classes in canmessage.py. Delete travis yml and create mkdocs, #3

--- a/src/caroa04/canmessage.py
+++ b/src/caroa04/canmessage.py
@@ -359,8 +359,8 @@ class CanMessageRW(CanMessage):
 
     @node_id.setter
     def node_id(self, value):
-        self.read_id = (self.read_id & 0xFFFFFF00) | value
-        self.write_id = (self.write_id & 0xFFFFFF00) | value
+        self.read_id = (self.read_id & 0x700) | value
+        self.write_id = (self.write_id & 0x700) | value
         self._node_id = value
 
     def write(self):
@@ -379,14 +379,7 @@ class CanMessageRW(CanMessage):
                                   is_extended_id=self.is_extended)
             logging.debug(message)
             self.bus.send(message)
-
-            self.bus.set_filters([{"can_id": self.write_id, "can_mask": 0x7ff, "extended": False}])
-            sts = self.bus.recv(5)
-            if sts is not None and sts.arbitration_id == self.write_id and sts.dlc > 0:
-                self.update_payload(sts.data)
-            else:
-                logging.warning('Could not get a response from the device')
-            self.bus.set_filters()
+            self.bus.recv(1)
 
     def read(self):
         """
@@ -402,15 +395,7 @@ class CanMessageRW(CanMessage):
                                   is_extended_id=self.is_extended)
             logging.debug(message)
             self.bus.send(message)
-
-            self.bus.set_filters([{"can_id": self.read_id, "can_mask": 0x7ff, "extended": False}])
-            sts = self.bus.recv(5)
-            if sts is not None and sts.arbitration_id == self.read_id and sts.dlc > 0:
-                logging.debug(sts)
-                self.update_payload(sts.data)
-            else:
-                logging.warning('Could not get a response from the device')
-            self.bus.set_filters()
+            self.bus.recv(1)
 
 
 if __name__ == "__main__":

--- a/src/caroa04/caroa04.py
+++ b/src/caroa04/caroa04.py
@@ -151,11 +151,11 @@ class CaroA04:
     def shutdown(self):
         if self.bus is not None:
             self.bus.shutdown()  # free the port
-            self.bus = None
-            self.message_do.bus = None
-            self.message_di.bus = None
-            self.message_nodeid.bus = None
-            self.message_bitrate.bus = None
+        self.bus = None
+        self.message_do.bus = None
+        self.message_di.bus = None
+        self.message_nodeid.bus = None
+        self.message_bitrate.bus = None
 
 
 if __name__ == "__main__":

--- a/src/caroa04/caroa04.py
+++ b/src/caroa04/caroa04.py
@@ -54,6 +54,7 @@ class CaroA04:
     def __init__(self):
         self._node_id = DEFAULT_NODEID
         self.bus = None
+        self.notifier = None
 
         self.message_do = CanMessageRW(self._node_id, MSGID_DO_READ, MSGID_DO_WRITE, dlc=8)
         self.message_di = CanMessageRW(self._node_id, MSGID_DI_READ, MSGID_DI_READ, dlc=8)
@@ -122,10 +123,26 @@ class CaroA04:
 
         if self.bus is None:
             self.bus = can.Bus(interface=interface, channel=channel, bitrate=bitrate)
-            self.message_do.bus = self.bus
-            self.message_di.bus = self.bus
-            self.message_nodeid.bus = self.bus
-            self.message_bitrate.bus = self.bus
+            self.notifier = can.Notifier(self.bus, [self.listener])
+
+        self.message_do.bus = self.bus
+        self.message_di.bus = self.bus
+        self.message_nodeid.bus = self.bus
+        self.message_bitrate.bus = self.bus
+
+    def listener(self, msg):
+        if msg.arbitration_id in (self.message_do.read_id, self.message_do.write_id):
+            logging.debug(f"Response from caroA04> {msg}")
+            self.message_do.update_payload(msg.data)
+        elif msg.arbitration_id in (self.message_di.read_id, self.message_di.write_id):
+            logging.info(msg)
+            self.message_di.update_payload(msg.data)
+        elif msg.arbitration_id in (self.message_bitrate.read_id, self.message_bitrate.write_id):
+            logging.info(msg)
+            self.message_bitrate.update_payload(msg.data)
+        elif msg.arbitration_id in (self.message_nodeid.read_id, self.message_nodeid.write_id):
+            logging.info(msg)
+            self.message_nodeid.update_payload(msg.data)
 
     def stop(self):
         """Stops any ongoing thread - unused"""
@@ -144,10 +161,7 @@ class CaroA04:
 if __name__ == "__main__":
     caro = CaroA04()
     caro.start(0xE0, 'pcan', 250000, 'PCAN_USBBUS2')
-    print(caro.do1.phys)
     caro.do1.phys = True
     print(caro.do1.phys)
-    time.sleep(0.5)
     caro.do1.phys = False
-    print(caro.do1.phys)
     caro.shutdown()

--- a/src/caroa04/caroa04.py
+++ b/src/caroa04/caroa04.py
@@ -123,7 +123,7 @@ class CaroA04:
 
         if self.bus is None:
             self.bus = can.Bus(interface=interface, channel=channel, bitrate=bitrate)
-            self.notifier = can.Notifier(self.bus, [self.listener])
+            self.notifier = can.Notifier(self.bus, [self.listener], timeout=2.0)
 
         self.message_do.bus = self.bus
         self.message_di.bus = self.bus
@@ -145,13 +145,14 @@ class CaroA04:
             self.message_nodeid.update_payload(msg.data)
 
     def stop(self):
-        """Stops any ongoing thread - unused"""
-        pass
+        """Stops any ongoing thread"""
+        if self.notifier is not None:
+            self.notifier.stop()
 
     def shutdown(self):
         if self.bus is not None:
             self.bus.shutdown()  # free the port
-        self.bus = None
+            self.bus = None
         self.message_do.bus = None
         self.message_di.bus = None
         self.message_nodeid.bus = None

--- a/tests/test_caroa04.py
+++ b/tests/test_caroa04.py
@@ -1,4 +1,3 @@
-import threading
 import pytest
 import can
 
@@ -58,7 +57,7 @@ class VirtualDevice:
 
         if self.bus is None:
             self.bus = can.interface.Bus(interface='virtual')
-            self.notifier = can.Notifier(self.bus, [self.listener])
+            self.notifier = can.Notifier(self.bus, [self.listener], timeout=2.0)
 
     def listener(self, msg):
         if msg.arbitration_id == self.message_do_get.arbitration_id:
@@ -79,7 +78,8 @@ class VirtualDevice:
                                       is_extended_id=False))
 
     def stop(self):
-        pass
+        if self.notifier is not None:
+            self.notifier.stop()
 
     def shutdown(self):
         if self.bus is not None:
@@ -100,9 +100,6 @@ class TestVirtualCanIoExp1:
     def setup_teardown_class(self, caro, virtualdevice):
         """Fixture to execute asserts before and after a sccenario is run"""
         caro.start(0xE0, 'virtual')
-        virtualdevice.bus = caro.bus
-        caro.notifier.add_listener(virtualdevice.listener)
-
         virtualdevice.start(0xE0)
 
         yield


### PR DESCRIPTION
- Use better mask for read_id and write_id. 
- Stop using filters when waiting on device's response, in case the bus is used by other devices.
- Use notifier to share the received messages with all devices.